### PR TITLE
docs: fix copy command for hook installation

### DIFF
--- a/apps/www/app/docs/@details/[name]/page.tsx
+++ b/apps/www/app/docs/@details/[name]/page.tsx
@@ -191,7 +191,7 @@ export default async function HookPage({
           <div className="relative">
             <Terminal>npx usehooks-cli@latest add {hook.name}</Terminal>
             <CopyToClipboard
-              text={`npx usehooks-cli@latest add ${hook.title}`}
+              text={`npx usehooks-cli@latest add ${hook.name}`}
               className="absolute top-2 right-2"
             />
           </div>


### PR DESCRIPTION
This pull request includes a minor fix to the `HookPage` component to ensure the correct hook identifier is used when copying the installation command.

* Updated the `CopyToClipboard` component to use `hook.name` instead of `hook.title` for the command text, ensuring consistency with the displayed installation command and the actual functioning code. ([apps/www/app/docs/@details/[name]/page.tsxL194-R194](diffhunk://#diff-492132a71fbac9f7c8c6156aab57abc265de537345902cd80a5495d9d5cd0870L194-R194))