### PR TITLE
fix: add missing useEffect dependencies for device orientation

### DIFF
--- a/packages/hooks/src/use-device-orientation/index.ts
+++ b/packages/hooks/src/use-device-orientation/index.ts
@@ -153,7 +153,7 @@ export const useDeviceOrientation = (
         stopListening();
       }
     };
-  }, [options.absolute, isSupported]);
+  }, [options.absolute, isSupported, stopListening, isListening, requestPermission, startListening]);
 
   // Cleanup on unmount
   useEffect(() => {


### PR DESCRIPTION
The error is only visible in Oxlint; it doesn't show up in ESlint.

React Hook useEffect has missing dependencies: 'stopListening', 'isListening', 'requestPermission', and 'startListening'
help: Either include it or remove the dependency array.
use-device-orientation.ts(153, 9): 
use-device-orientation.ts(152, 11): 
use-device-orientation.ts(142, 37): 
use-device-orientation.ts(144, 11): 
use-device-orientation.ts(156, 6): 