### PR TITLE
refactor(useDeviceOrientation): move isSupported outside hook

### DIFF
--- a/packages/hooks/src/use-device-orientation/index.ts
+++ b/packages/hooks/src/use-device-orientation/index.ts
@@ -33,6 +33,10 @@ declare global {
   }
 }
 
+// Check if DeviceOrientationEvent is supported
+const isSupported =
+  typeof window !== "undefined" && "DeviceOrientationEvent" in window;
+
 export const useDeviceOrientation = (
   options: UseDeviceOrientationOptions = {}
 ): UseDeviceOrientationReturn => {
@@ -41,10 +45,6 @@ export const useDeviceOrientation = (
   );
   const [isListening, setIsListening] = useState(false);
   const [error, setError] = useState<string | null>(null);
-
-  // Check if DeviceOrientationEvent is supported
-  const isSupported =
-    typeof window !== "undefined" && "DeviceOrientationEvent" in window;
 
   // Handle orientation change
   const handleOrientationChange = useCallback(
@@ -95,7 +95,7 @@ export const useDeviceOrientation = (
       setError(errorMessage);
       return false;
     }
-  }, [isSupported]);
+  }, []);
 
   // Start listening to orientation changes
   const startListening = useCallback(() => {
@@ -114,7 +114,7 @@ export const useDeviceOrientation = (
         err instanceof Error ? err.message : "Failed to start listening";
       setError(errorMessage);
     }
-  }, [isSupported, isListening, handleOrientationChange]);
+  }, [isListening, handleOrientationChange]);
 
   // Stop listening to orientation changes
   const stopListening = useCallback(() => {
@@ -133,7 +133,7 @@ export const useDeviceOrientation = (
         err instanceof Error ? err.message : "Failed to stop listening";
       setError(errorMessage);
     }
-  }, [isSupported, isListening, handleOrientationChange]);
+  }, [isListening, handleOrientationChange]);
 
   // Auto-start listening if absolute option is provided
   useEffect(() => {
@@ -153,7 +153,7 @@ export const useDeviceOrientation = (
         stopListening();
       }
     };
-  }, [options.absolute, isSupported, stopListening, isListening, requestPermission, startListening]);
+  }, [options.absolute, stopListening, isListening, requestPermission, startListening]);
 
   // Cleanup on unmount
   useEffect(() => {

--- a/packages/hooks/src/use-device-orientation/index.ts
+++ b/packages/hooks/src/use-device-orientation/index.ts
@@ -34,8 +34,11 @@ declare global {
 }
 
 // Check if DeviceOrientationEvent is supported
-const isSupported =
-  typeof window !== "undefined" && "DeviceOrientationEvent" in window;
+export const isDeviceOrientationSupported = 
+  typeof globalThis !== 'undefined' && 'DeviceOrientationEvent' in globalThis;
+
+// Backwards-compatible alias used internally (keeps existing name)
+const isSupported = isDeviceOrientationSupported;
 
 export const useDeviceOrientation = (
   options: UseDeviceOrientationOptions = {}


### PR DESCRIPTION
`isSupported` was being calculated on every render of the hook, even though it represents a characteristic of the environment rather than the hook itself.

Moving it outside the hook also removes the need to include it in dependency arrays, keeping the code cleaner and easier to follow.

This is not a performance-related change. The main reason is code cleanliness and better separation between environment capabilities and hook state.

I’m suggesting this as a code style and cleanup improvement, **but there may be a specific reason for keeping it inside the hook that I’m not aware of**. Normally, during browser usage, the existence of a browser API does not change, so treating `isSupported` as an environment-level constant seems more appropriate.